### PR TITLE
Use user-error instead of error where applicable

### DIFF
--- a/goto-last-change.el
+++ b/goto-last-change.el
@@ -82,7 +82,7 @@ With a prefix arg (optional arg MARK-POINT non-nil), set mark so \
 will return point to the current position."
   (interactive "P")
   (when (eq buffer-undo-list t)
-    (error "No undo information in this buffer"))
+    (user-error "No undo information in this buffer"))
   (when mark-point
     (push-mark))
   (unless minimal-line-distance
@@ -124,10 +124,10 @@ will return point to the current position."
           ((and (eq this-command last-command)
                 goto-last-change-undo)
            (setq goto-last-change-undo nil)
-           (error "No further undo information"))
+           (user-error "No further undo information"))
           (t
            (setq goto-last-change-undo nil)
-           (error "Buffer not modified")))))
+           (user-error "Buffer not modified")))))
 
 (defun goto-last-change-with-auto-marks (&optional minimal-line-distance)
   "Calls goto-last-change and sets the mark at only the first


### PR DESCRIPTION
Quoting from section 11.7.3.1 How to Signal an Error in the GNU Emacs
Lisp Reference Manual (version 26.2):

"[user-error] behaves exactly like error, except that it uses the error
symbol user-error rather than error. [It] is intended to report errors
on the part of the user, rather than errors in the code itself. For
example, if you try to use the command Info-history-back (l) to move
back beyond the start of your Info browsing history, Emacs signals a
user-error. Such errors do not cause entry to the debugger, even when
debug-on-error is non-nil."